### PR TITLE
Fixed windows compatibility issue

### DIFF
--- a/lua/bruno/init.lua
+++ b/lua/bruno/init.lua
@@ -293,7 +293,7 @@ local function run_bruno()
 	end
 
 	root_dir = vim.fn.fnamemodify(root_dir, ":p:h")
-	local temp_file = vim.fn.system("mktemp"):gsub("\n", "")
+	local temp_file = vim.fn.tempname()
 	local cmd = string.format(
 		"cd %s && bru run %s -o %s",
 		vim.fn.shellescape(root_dir),


### PR DESCRIPTION
Windows doesn't have the `mktemp` tool, so adjusted the code accordingly to use vim in-built functions. Otherwise, I'd end up with this error when running `:BrunoRun`
<img width="1329" height="162" alt="image" src="https://github.com/user-attachments/assets/2ace6777-a5e3-4058-bab4-6ac061720873" />

> Note the other areas that calls `vim.fn.system()` are fine since it calls `cat`  and `rm`, which windows has in-built aliases for.