### PR TITLE
Add OpenCollection YAML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 # Features:
 
-- **Execute Bruno requests** - Run `.bru` files directly from Neovim
-- **Smart fallback** - Uses last opened `.bru` file when current buffer isn't a Bruno file
+- **Execute Bruno requests** - Run `.bru` and `.yml` (OpenCollection) files directly from Neovim
+- **Smart fallback** - Uses last opened Bruno file when current buffer isn't a Bruno file
 - **Environment switching** - Select Bruno environments via a picker (`telescope`, `fzf-lua`, or `snacks`)
 - **Formatted output** - Clean response display with request details and JSON formatting
 - **Output toggle** - Switch between formatted and raw JSON output
-- **Content search** - Search Bruno files by their contents using your chosen picker
+- **Content search** - Search Bruno files (`.bru` and `.yml`) by their contents using your chosen picker
 - **Persistent sidebar** - Reuses output buffer to avoid window clutter
 
 ## Screenshots:
@@ -63,7 +63,7 @@ Can also be installed from [nixpkgs](https://search.nixos.org/packages?channel=u
 ```
 
 # Usage:
-### Run currently opened .bru file
+### Run currently opened Bruno request (.bru / .yml)
 
 :BrunoRun
 
@@ -71,7 +71,7 @@ Can also be installed from [nixpkgs](https://search.nixos.org/packages?channel=u
 
 :BrunoEnv
 
-### Search for .bru files
+### Search for Bruno files (.bru / .yml)
 
 :BrunoSearch
 

--- a/lua/bruno/init.lua
+++ b/lua/bruno/init.lua
@@ -418,14 +418,18 @@ end
 
 local function find_environments_dir()
 	local search_dir = vim.fn.expand("%:p:h")
-	local env_dir = vim.fn.finddir("environments", search_dir .. ";")
-
-	if env_dir == "" and vim.g.last_bruno_file then
-		search_dir = vim.fn.fnamemodify(vim.g.last_bruno_file, ":p:h")
-		env_dir = vim.fn.finddir("environments", search_dir .. ";")
+	local root = find_collection_root(search_dir)
+	if not root and vim.g.last_bruno_file then
+		root = find_collection_root(vim.fn.fnamemodify(vim.g.last_bruno_file, ":p:h"))
 	end
-
-	return env_dir
+	if not root then
+		return ""
+	end
+	local env_dir = root .. "/environments"
+	if vim.fn.isdirectory(env_dir) == 1 then
+		return env_dir
+	end
+	return ""
 end
 
 local function set_env_picker()

--- a/lua/bruno/init.lua
+++ b/lua/bruno/init.lua
@@ -5,7 +5,7 @@ local Path = require("plenary.path")
 
 -- Configuration
 M.current_env = nil
-vim.g.last_bru_file = nil
+vim.g.last_bruno_file = nil
 M.last_raw_output = nil
 
 M.show_formatted_output = true
@@ -18,7 +18,7 @@ local search_pickers = {
 		fzf.live_grep({
 			prompt = prompt .. ": ",
 			search_paths = search_dirs,
-			rg_opts = "--column --line-number --no-heading --color=always --smart-case --glob=*.bru",
+			rg_opts = "--column --line-number --no-heading --color=always --smart-case --glob=*.bru --glob=*.yml",
 			actions = {
 				["default"] = function(selected)
 					local raw = selected[1]
@@ -36,7 +36,7 @@ local search_pickers = {
 		local snacks = require("snacks")
 		snacks.picker.grep({
 			prompt = prompt .. ": ",
-			glob = "*.bru",
+			glob = "{*.bru,*.yml}",
 			dirs = search_dirs,
 			on_select = function(item)
 				vim.cmd("edit " .. item.file)
@@ -51,7 +51,7 @@ local search_pickers = {
 		telescope.live_grep({
 			prompt_title = prompt,
 			search_dirs = search_dirs,
-			glob_pattern = "*.bru",
+			glob_pattern = "{*.bru,*.yml}",
 			attach_mappings = function(prompt_bufnr, map)
 				actions.select_default:replace(function()
 					actions.close(prompt_bufnr)
@@ -166,17 +166,61 @@ local function create_or_get_sidebar()
 	return bufnr
 end
 
+local function get_current_request_file()
+	local current_file = vim.fn.expand("%:p")
+	local ext = vim.fn.fnamemodify(current_file, ":e")
+	if ext == "bru" or ext == "yml" then
+		vim.g.last_bruno_file = current_file
+		return current_file
+	end
+
+	local last = vim.g.last_bruno_file
+	if last and vim.fn.filereadable(last) == 1 then
+		return last
+	end
+
+	print("Current file is not a .bru/.yml file and no valid last Bruno file found")
+	return nil
+end
+
+local function find_collection_root(start_dir)
+	local markers = { "bruno.json", "opencollection.yml", "collection.bru" }
+	local dir = vim.fn.fnamemodify(start_dir, ":p")
+	while true do
+		for _, marker in ipairs(markers) do
+			if vim.fn.filereadable(dir .. "/" .. marker) == 1 then
+				return dir
+			end
+		end
+		local parent = vim.fn.fnamemodify(dir, ":h")
+		if parent == dir then
+			return nil
+		end
+		dir = parent
+	end
+end
+
 -- Main Functions
 local function bruno_search()
 	local collections = get_valid_collections()
-	if #collections == 0 then
-		print("No valid Bruno collections found.")
-		return
-	end
-
 	local search_dirs = vim.tbl_map(function(collection)
 		return collection.path
 	end, collections)
+
+	if #search_dirs == 0 then
+		local current_file = get_current_request_file()
+		if current_file then
+			local root = find_collection_root(vim.fn.fnamemodify(current_file, ":p:h"))
+			if root then
+				search_dirs = { root }
+			end
+		end
+	end
+
+	if #search_dirs == 0 then
+		print("No valid Bruno collections found.")
+		return
+	end
 
 	local picker_fn = search_pickers[M.picker] or search_pickers["telescope"]
 	picker_fn(search_dirs, "Bruno Files")
@@ -264,35 +308,17 @@ local function format_bruno_output(raw_output)
 	return formatted
 end
 
-local function get_current_bru_file()
-	local current_file = vim.fn.expand("%:p")
-	if vim.fn.fnamemodify(current_file, ":e") == "bru" then
-		vim.g.last_bru_file = current_file
-		return current_file
-	end
-
-	local last_bru = vim.g.last_bru_file
-	if last_bru and vim.fn.filereadable(last_bru) == 1 then
-		return last_bru
-	end
-
-	print("Current file is not a .bru file and no valid last .bru file found")
-	return nil
-end
-
 local function run_bruno()
-	local current_file = get_current_bru_file()
+	local current_file = get_current_request_file()
 	if not current_file then
 		return
 	end
 
-	local root_dir = vim.fn.findfile("bruno.json", vim.fn.fnamemodify(current_file, ":p:h") .. ";")
-	if root_dir == "" then
-		print("Bruno collection root not found. Please ensure the .bru file is in a Bruno collection.")
+	local root_dir = find_collection_root(vim.fn.fnamemodify(current_file, ":p:h"))
+	if not root_dir then
+		print("Bruno collection root not found. Please ensure the file is in a Bruno collection.")
 		return
 	end
-
-	root_dir = vim.fn.fnamemodify(root_dir, ":p:h")
 	local temp_file = vim.fn.tempname()
 	local cmd = string.format(
 		"cd %s && bru run %s -o %s",
@@ -394,8 +420,8 @@ local function find_environments_dir()
 	local search_dir = vim.fn.expand("%:p:h")
 	local env_dir = vim.fn.finddir("environments", search_dir .. ";")
 
-	if env_dir == "" and vim.g.last_bru_file then
-		search_dir = vim.fn.fnamemodify(vim.g.last_bru_file, ":p:h")
+	if env_dir == "" and vim.g.last_bruno_file then
+		search_dir = vim.fn.fnamemodify(vim.g.last_bruno_file, ":p:h")
 		env_dir = vim.fn.finddir("environments", search_dir .. ";")
 	end
 
@@ -406,14 +432,14 @@ local function set_env_picker()
 	local env_dir = find_environments_dir()
 	if env_dir == "" then
 		print(
-			"Environments directory not found. You need to run BrunoRun on a .bru file first, or have the current buffer be a .bru file."
+			"Environments directory not found. You need to run BrunoRun on a .bru/.yml file first, or have the current buffer be a Bruno file."
 		)
 		return
 	end
 
-	local env_files = vim.fn.glob(env_dir .. "/*.bru", false, true)
+	local env_files = vim.fn.glob(env_dir .. "/*.{bru,yml,json}", false, true)
 	if #env_files == 0 then
-		print("No .bru files found in the environments directory.")
+		print("No environment files found in the environments directory.")
 		return
 	end
 


### PR DESCRIPTION
## Summary

Add support for Bruno's [OpenCollection YAML format](https://spec.opencollection.com/) — the new standard YAML-based collection format introduced in Bruno v3.0.0+, default since v3.1.0.

OpenCollection stores requests as `.yml` files with `opencollection.yml` as the collection root (replacing legacy `bruno.json`), enabling human-readable, git-friendly, and tool-agnostic API collections.

## Changes

- **`.yml` request file support** — `BrunoRun` now accepts both `.bru` and `.yml` request files
- **Dual collection root detection** — Walks up the directory tree looking for `bruno.json`, `opencollection.yml`, or `collection.bru` to discover the collection root
- **Search across both formats** — `BrunoSearch` searches `*.bru` and `*.yml` files in all picker integrations (telescope, fzf-lua, snacks)
- **Environment file expansion** — `BrunoEnv` discovers environment files in `.bru`, `.yml`, and `.json` formats
- **Auto-detection fallback** — `BrunoSearch` now falls back to auto-detected collection root when no `collection_paths` are configured
- **Robust directory walking** — Replaced `findfile`/`finddir` with manual upward directory walker for reliable collection and environment discovery across both formats
- **Updated docs** — README reflects both `.bru` and `.yml` support

## Related

- [OpenCollection Specification](https://spec.opencollection.com/)
- [Bruno OpenCollection YAML docs](https://docs.usebruno.com/opencollection-yaml/overview)