### PR TITLE
Format Bruno output as valid Markdown with headers and folds

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,29 @@ Can also be installed from [nixpkgs](https://search.nixos.org/packages?channel=u
 }
 ```
 
+## render-markdown.nvim
+
+For richer output rendering, pair with [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim). The formatted output is valid Markdown (`filetype=markdown`), so render-markdown will automatically render headings, code fences, bold text, etc.
+
+```lua
+{
+    "MeanderingProgrammer/render-markdown.nvim",
+    opts = {},
+    -- The Bruno Output buffer will be picked up automatically via filetype.
+}
+```
+
+If you want to restrict rendering to only the Bruno output buffer, use:
+
+```lua
+{
+    "MeanderingProgrammer/render-markdown.nvim",
+    opts = {
+        buftype = { "nofile" }, -- Bruno Output buffer uses buftype=nofile
+    },
+}
+```
+
 # Usage:
 ### Run currently opened Bruno request (.bru / .yml)
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 # Features:
 
-- **Execute Bruno requests** - Run `.bru` files directly from Neovim
-- **Smart fallback** - Uses last opened `.bru` file when current buffer isn't a Bruno file
+- **Execute Bruno requests** - Run `.bru` and `.yml` (OpenCollection) files directly from Neovim
+- **Smart fallback** - Uses last opened Bruno file when current buffer isn't a Bruno file
 - **Environment switching** - Select Bruno environments via a picker (`telescope`, `fzf-lua`, or `snacks`)
 - **Formatted output** - Clean response display with request details and JSON formatting
 - **Output toggle** - Switch between formatted and raw JSON output
-- **Content search** - Search Bruno files by their contents using your chosen picker
+- **Content search** - Search Bruno files (`.bru` and `.yml`) by their contents using your chosen picker
 - **Persistent sidebar** - Reuses output buffer to avoid window clutter
 
 ## Screenshots:
@@ -63,7 +63,7 @@ Can also be installed from [nixpkgs](https://search.nixos.org/packages?channel=u
 ```
 
 # Usage:
-### Run currently opened .bru file
+### Run currently opened Bruno request (.bru / .yml)
 
 :BrunoRun
 
@@ -71,7 +71,7 @@ Can also be installed from [nixpkgs](https://search.nixos.org/packages?channel=u
 
 :BrunoEnv
 
-### Search for .bru files
+### Search for Bruno files (.bru / .yml)
 
 :BrunoSearch
 

--- a/lua/bruno/init.lua
+++ b/lua/bruno/init.lua
@@ -126,7 +126,7 @@ local function get_valid_collections()
 end
 
 local function is_not_nil(value)
-	return value ~= nil and value ~= vim.NIL
+	return value ~= nil and value ~= vim.NIL and value ~= vim.NULL
 end
 
 local function set_buffer_properties(bufnr, name)
@@ -263,13 +263,13 @@ local function pretty_json_str(s, indent)
 end
 
 local function format_headers(headers)
-	if not headers or #headers == 0 then
+	if headers == nil or headers == vim.NULL or headers == vim.NIL then
 		return {}
 	end
 	local lines = {}
-	for _, h in ipairs(headers) do
-		if h.disabled ~= true then
-			table.insert(lines, string.format("%s: %s", h.name, h.value))
+	for name, value in pairs(headers) do
+		if value ~= nil and value ~= vim.NULL and value ~= vim.NIL then
+			table.insert(lines, string.format("%s: %s", name, value))
 		end
 	end
 	return lines
@@ -291,18 +291,15 @@ local function format_bruno_output(raw_output)
 
 	local req_headers = format_headers(result.request.headers)
 	if #req_headers > 0 then
-		table.insert(formatted, "{{{ Request Headers")
+		table.insert(formatted, "## Headers")
 		table.insert(formatted, "```")
 		for _, line in ipairs(req_headers) do
 			table.insert(formatted, line)
 		end
 		table.insert(formatted, "```")
-		table.insert(formatted, "}}}")
+		table.insert(formatted, "## End Headers")
 		table.insert(formatted, "")
 	end
-
-	table.insert(formatted, "---")
-	table.insert(formatted, "")
 
 	table.insert(formatted, "# Response")
 	table.insert(formatted, "")
@@ -324,18 +321,15 @@ local function format_bruno_output(raw_output)
 
 	local res_headers = format_headers(result.response.headers)
 	if #res_headers > 0 then
-		table.insert(formatted, "{{{ Response Headers")
+		table.insert(formatted, "## Headers")
 		table.insert(formatted, "```")
 		for _, line in ipairs(res_headers) do
 			table.insert(formatted, line)
 		end
 		table.insert(formatted, "```")
-		table.insert(formatted, "}}}")
+		table.insert(formatted, "## End Headers")
 		table.insert(formatted, "")
 	end
-
-	table.insert(formatted, "---")
-	table.insert(formatted, "")
 
 	if is_not_nil(result.response.data) then
 		table.insert(formatted, "# Response Data")
@@ -406,6 +400,7 @@ local function run_bruno()
 				if M.show_formatted_output then
 					vim.api.nvim_buf_set_option(bufnr, "filetype", "markdown")
 					vim.api.nvim_buf_set_option(bufnr, "foldmethod", "marker")
+					vim.api.nvim_buf_set_option(bufnr, "foldmarker", "## Headers,End Headers")
 					vim.api.nvim_buf_set_option(bufnr, "foldlevel", 0)
 					local ok, result = pcall(format_bruno_output, output)
 					if ok then
@@ -455,6 +450,7 @@ local function toggle_output_format()
 			if M.show_formatted_output then
 				vim.api.nvim_buf_set_option(bufnr, "filetype", "markdown")
 				vim.api.nvim_buf_set_option(bufnr, "foldmethod", "marker")
+				vim.api.nvim_buf_set_option(bufnr, "foldmarker", "## Headers,End Headers")
 				vim.api.nvim_buf_set_option(bufnr, "foldlevel", 0)
 				local ok, result = pcall(format_bruno_output, M.last_raw_output)
 				lines = ok and result or vim.split(M.last_raw_output, "\n")

--- a/lua/bruno/init.lua
+++ b/lua/bruno/init.lua
@@ -262,6 +262,19 @@ local function pretty_json_str(s, indent)
 	return table.concat(out)
 end
 
+local function format_headers(headers)
+	if not headers or #headers == 0 then
+		return {}
+	end
+	local lines = {}
+	for _, h in ipairs(headers) do
+		if h.disabled ~= true then
+			table.insert(lines, string.format("%s: %s", h.name, h.value))
+		end
+	end
+	return lines
+end
+
 local function format_bruno_output(raw_output)
 	local ok, data = pcall(vim.json.decode, raw_output)
 	if not ok or not data.results or #data.results == 0 then
@@ -271,28 +284,62 @@ local function format_bruno_output(raw_output)
 	local formatted = {}
 	local result = data.results[1]
 
-	table.insert(formatted, "REQUEST DETAILS:")
-	table.insert(formatted, string.format("  Method: %s", result.request.method))
-	table.insert(formatted, string.format("  URL: %s", result.request.url))
+	table.insert(formatted, "# Request")
+	table.insert(formatted, "")
+	table.insert(formatted, string.format("%s `%s`", result.request.method, result.request.url))
 	table.insert(formatted, "")
 
-	table.insert(formatted, "RESPONSE:")
+	local req_headers = format_headers(result.request.headers)
+	if #req_headers > 0 then
+		table.insert(formatted, "{{{ Request Headers")
+		table.insert(formatted, "```")
+		for _, line in ipairs(req_headers) do
+			table.insert(formatted, line)
+		end
+		table.insert(formatted, "```")
+		table.insert(formatted, "}}}")
+		table.insert(formatted, "")
+	end
+
+	table.insert(formatted, "---")
+	table.insert(formatted, "")
+
+	table.insert(formatted, "# Response")
+	table.insert(formatted, "")
+
 	if is_not_nil(result.error) then
-		table.insert(formatted, string.format("  Error: %s", result.error))
+		table.insert(formatted, string.format("**Error:** %s", result.error))
+		table.insert(formatted, "")
 	end
 
 	local status_text = is_not_nil(result.response.statusText) and " " .. tostring(result.response.statusText) or ""
 
 	table.insert(
 		formatted,
-		string.format("  Status: %s%s", tostring(result.response.status or "(no status)"), status_text)
+		string.format("Status: **%s%s**", tostring(result.response.status or "(no status)"), status_text)
 	)
 
-	table.insert(formatted, string.format("  Response Time: %dms", result.response.responseTime))
+	table.insert(formatted, string.format("Time: **%dms**", result.response.responseTime))
+	table.insert(formatted, "")
+
+	local res_headers = format_headers(result.response.headers)
+	if #res_headers > 0 then
+		table.insert(formatted, "{{{ Response Headers")
+		table.insert(formatted, "```")
+		for _, line in ipairs(res_headers) do
+			table.insert(formatted, line)
+		end
+		table.insert(formatted, "```")
+		table.insert(formatted, "}}}")
+		table.insert(formatted, "")
+	end
+
+	table.insert(formatted, "---")
 	table.insert(formatted, "")
 
 	if is_not_nil(result.response.data) then
-		table.insert(formatted, "RESPONSE DATA:")
+		table.insert(formatted, "# Response Data")
+		table.insert(formatted, "")
 		table.insert(formatted, "```json")
 
 		local data_content = result.response.data == null and "null"
@@ -357,7 +404,9 @@ local function run_bruno()
 				local lines
 
 				if M.show_formatted_output then
-					vim.api.nvim_buf_set_option(bufnr, "filetype", "text")
+					vim.api.nvim_buf_set_option(bufnr, "filetype", "markdown")
+					vim.api.nvim_buf_set_option(bufnr, "foldmethod", "marker")
+					vim.api.nvim_buf_set_option(bufnr, "foldlevel", 0)
 					local ok, result = pcall(format_bruno_output, output)
 					if ok then
 						lines = result
@@ -404,7 +453,9 @@ local function toggle_output_format()
 		if bufnr ~= -1 then
 			local lines
 			if M.show_formatted_output then
-				vim.api.nvim_buf_set_option(bufnr, "filetype", "text")
+				vim.api.nvim_buf_set_option(bufnr, "filetype", "markdown")
+				vim.api.nvim_buf_set_option(bufnr, "foldmethod", "marker")
+				vim.api.nvim_buf_set_option(bufnr, "foldlevel", 0)
 				local ok, result = pcall(format_bruno_output, M.last_raw_output)
 				lines = ok and result or vim.split(M.last_raw_output, "\n")
 			else

--- a/lua/bruno/init.lua
+++ b/lua/bruno/init.lua
@@ -317,6 +317,9 @@ local function format_bruno_output(raw_output)
 	)
 
 	table.insert(formatted, string.format("Time: **%dms**", result.response.responseTime))
+	if M.current_env then
+		table.insert(formatted, string.format("Env: **%s**", M.current_env))
+	end
 	table.insert(formatted, "")
 
 	local res_headers = format_headers(result.response.headers)

--- a/lua/bruno/init.lua
+++ b/lua/bruno/init.lua
@@ -418,14 +418,18 @@ end
 
 local function find_environments_dir()
 	local search_dir = vim.fn.expand("%:p:h")
-	local env_dir = vim.fn.finddir("environments", search_dir .. ";")
-
-	if env_dir == "" and vim.g.last_bruno_file then
-		search_dir = vim.fn.fnamemodify(vim.g.last_bruno_file, ":p:h")
-		env_dir = vim.fn.finddir("environments", search_dir .. ";")
+	local root = find_collection_root(search_dir)
+	if not root and vim.g.last_bruno_file then
+		root = find_collection_root(vim.fn.fnamemodify(vim.g.last_bruno_file, ":p:h"))
 	end
-
-	return env_dir
+	if not root then
+		return ""
+	end
+	local env_dir = root .. "/environments"
+	if vim.fn.isdirectory(env_dir) == 1 then
+		return env_dir
+	end
+	return ""
 end
 
 local function set_env_picker()

--- a/lua/bruno/init.lua
+++ b/lua/bruno/init.lua
@@ -5,7 +5,7 @@ local Path = require("plenary.path")
 
 -- Configuration
 M.current_env = nil
-vim.g.last_bru_file = nil
+vim.g.last_bruno_file = nil
 M.last_raw_output = nil
 
 M.show_formatted_output = true
@@ -18,7 +18,7 @@ local search_pickers = {
 		fzf.live_grep({
 			prompt = prompt .. ": ",
 			search_paths = search_dirs,
-			rg_opts = "--column --line-number --no-heading --color=always --smart-case --glob=*.bru",
+			rg_opts = "--column --line-number --no-heading --color=always --smart-case --glob=*.bru --glob=*.yml",
 			actions = {
 				["default"] = function(selected)
 					local raw = selected[1]
@@ -36,7 +36,7 @@ local search_pickers = {
 		local snacks = require("snacks")
 		snacks.picker.grep({
 			prompt = prompt .. ": ",
-			glob = "*.bru",
+			glob = "{*.bru,*.yml}",
 			dirs = search_dirs,
 			on_select = function(item)
 				vim.cmd("edit " .. item.file)
@@ -51,7 +51,7 @@ local search_pickers = {
 		telescope.live_grep({
 			prompt_title = prompt,
 			search_dirs = search_dirs,
-			glob_pattern = "*.bru",
+			glob_pattern = "{*.bru,*.yml}",
 			attach_mappings = function(prompt_bufnr, map)
 				actions.select_default:replace(function()
 					actions.close(prompt_bufnr)
@@ -166,17 +166,61 @@ local function create_or_get_sidebar()
 	return bufnr
 end
 
+local function get_current_request_file()
+	local current_file = vim.fn.expand("%:p")
+	local ext = vim.fn.fnamemodify(current_file, ":e")
+	if ext == "bru" or ext == "yml" then
+		vim.g.last_bruno_file = current_file
+		return current_file
+	end
+
+	local last = vim.g.last_bruno_file
+	if last and vim.fn.filereadable(last) == 1 then
+		return last
+	end
+
+	print("Current file is not a .bru/.yml file and no valid last Bruno file found")
+	return nil
+end
+
+local function find_collection_root(start_dir)
+	local markers = { "bruno.json", "opencollection.yml", "collection.bru" }
+	local dir = vim.fn.fnamemodify(start_dir, ":p")
+	while true do
+		for _, marker in ipairs(markers) do
+			if vim.fn.filereadable(dir .. "/" .. marker) == 1 then
+				return dir
+			end
+		end
+		local parent = vim.fn.fnamemodify(dir, ":h")
+		if parent == dir then
+			return nil
+		end
+		dir = parent
+	end
+end
+
 -- Main Functions
 local function bruno_search()
 	local collections = get_valid_collections()
-	if #collections == 0 then
-		print("No valid Bruno collections found.")
-		return
-	end
-
 	local search_dirs = vim.tbl_map(function(collection)
 		return collection.path
 	end, collections)
+
+	if #search_dirs == 0 then
+		local current_file = get_current_request_file()
+		if current_file then
+			local root = find_collection_root(vim.fn.fnamemodify(current_file, ":p:h"))
+			if root then
+				search_dirs = { root }
+			end
+		end
+	end
+
+	if #search_dirs == 0 then
+		print("No valid Bruno collections found.")
+		return
+	end
 
 	local picker_fn = search_pickers[M.picker] or search_pickers["telescope"]
 	picker_fn(search_dirs, "Bruno Files")
@@ -264,35 +308,17 @@ local function format_bruno_output(raw_output)
 	return formatted
 end
 
-local function get_current_bru_file()
-	local current_file = vim.fn.expand("%:p")
-	if vim.fn.fnamemodify(current_file, ":e") == "bru" then
-		vim.g.last_bru_file = current_file
-		return current_file
-	end
-
-	local last_bru = vim.g.last_bru_file
-	if last_bru and vim.fn.filereadable(last_bru) == 1 then
-		return last_bru
-	end
-
-	print("Current file is not a .bru file and no valid last .bru file found")
-	return nil
-end
-
 local function run_bruno()
-	local current_file = get_current_bru_file()
+	local current_file = get_current_request_file()
 	if not current_file then
 		return
 	end
 
-	local root_dir = vim.fn.findfile("bruno.json", vim.fn.fnamemodify(current_file, ":p:h") .. ";")
-	if root_dir == "" then
-		print("Bruno collection root not found. Please ensure the .bru file is in a Bruno collection.")
+	local root_dir = find_collection_root(vim.fn.fnamemodify(current_file, ":p:h"))
+	if not root_dir then
+		print("Bruno collection root not found. Please ensure the file is in a Bruno collection.")
 		return
 	end
-
-	root_dir = vim.fn.fnamemodify(root_dir, ":p:h")
 	local temp_file = vim.fn.tempname()
 	local cmd = string.format(
 		"cd %s && bru run %s -o %s",
@@ -394,8 +420,8 @@ local function find_environments_dir()
 	local search_dir = vim.fn.expand("%:p:h")
 	local env_dir = vim.fn.finddir("environments", search_dir .. ";")
 
-	if env_dir == "" and vim.g.last_bru_file then
-		search_dir = vim.fn.fnamemodify(vim.g.last_bru_file, ":p:h")
+	if env_dir == "" and vim.g.last_bruno_file then
+		search_dir = vim.fn.fnamemodify(vim.g.last_bruno_file, ":p:h")
 		env_dir = vim.fn.finddir("environments", search_dir .. ";")
 	end
 
@@ -406,14 +432,14 @@ local function set_env_picker()
 	local env_dir = find_environments_dir()
 	if env_dir == "" then
 		print(
-			"Environments directory not found. You need to run BrunoRun on a .bru file first, or have the current buffer be a .bru file."
+			"Environments directory not found. You need to run BrunoRun on a .bru/.yml file first, or have the current buffer be a Bruno file."
 		)
 		return
 	end
 
-	local env_files = vim.fn.glob(env_dir .. "/*.bru", false, true)
+	local env_files = vim.fn.glob(env_dir .. "/*.{bru,yml,json}", false, true)
 	if #env_files == 0 then
-		print("No .bru files found in the environments directory.")
+		print("No environment files found in the environments directory.")
 		return
 	end
 


### PR DESCRIPTION
## Summary

<img width="2541" height="1364" alt="image" src="https://github.com/user-attachments/assets/3a9ae9b2-c1e6-46c6-94fa-49679c92631e" />

Rewrites the `format_bruno_output` function to produce **valid Markdown** instead of plain text, adds request/response headers display, wraps headers in foldable `## Headers` / `## End Headers` sections, and sets the output buffer filetype to `markdown`.

## Changes

### Markdown template
- **Request** section: shows `GET \`url\`` inline, with request headers in a fenced code block
- **Response** section: shows status and timing in bold, with response headers in a fenced code block
- **Response Data** section: unchanged, keeps ` ```json ` fence with pretty-printed JSON
- Removed `---` separators for cleaner output

### Headers
- Fixed `format_headers()` to handle bru CLI's key-value object format (bru outputs `{"name": "value"}` not `[{name, value, disabled}]`)
- Added `vim.NULL` checks throughout — bru sets unspecified headers and error responses to JSON `null`
- Both request and response headers are now displayed (previously omitted entirely)

### Folds
- Header sections wrapped in `## Headers` / `## End Headers` with custom `foldmarker`
- Buffer `foldmethod` set to `marker` and `foldlevel` to `0`, so headers collapse by default

### Filetype
- Output buffer now uses `markdown` filetype (was `text`) for proper syntax highlighting

## Screenshot

<!-- User will add screenshot here -->